### PR TITLE
Default bucket write permission assumes aws v2 with fallback

### DIFF
--- a/lib/capistrano/s3/defaults.rb
+++ b/lib/capistrano/s3/defaults.rb
@@ -3,7 +3,7 @@ module Capistrano
     module Defaults
       DEFAULTS = {
         :deployment_path      => "public",
-        :bucket_write_options => { :acl => :public_read },
+        :bucket_write_options => { :acl =>  defined?(::Aws) ? :'public-read' : :public_read },
         :region               => 'us-east-1',
         :redirect_options     => {},
         :only_gzip            => false,


### PR DESCRIPTION
Fix for issue #37 regarding default bucket write permissions.